### PR TITLE
Fix change event on the select element

### DIFF
--- a/src/html/Options.html
+++ b/src/html/Options.html
@@ -20,7 +20,7 @@
               <h3 data-i18n="option_selection"></h3>
               <form>
                   <div>
-                      <select id="type" name="type_select" onchange="admSelectCheck(this);">
+                      <select id="type" name="type_select">
                           <option value="blanck" data-i18n="blanck_update"></option>
                           <option value="auto" data-i18n="automatic_update"></option>
                           <option id="local" value="0" data-i18n="local_update"></option>
@@ -70,7 +70,7 @@
                        
 
                    
-                    <div id="admDivCheck" style="display:none;"></div>
+                    <div id="admDivCheck" style="display:none;">
                        <h3 data-i18n="local_file_saving"></h3>
                             <span data-i18n="local_file_desc" class="local-file-desc"></span>
                        <br />
@@ -84,5 +84,6 @@
 
       <script src='/js/extra-permission.js'></script>
       <script src='/js/i18n.js'></script>
+      <script src='/js/Options.js'></script>
 </body>
 </html>

--- a/src/js/Options.js
+++ b/src/js/Options.js
@@ -6,18 +6,13 @@ const options = {
 
 };
 
-let admOptionValue = document.getElementById("local").value;
-{
-    if (nameSelect) {
-        admOptionValue = document.getElementById("local").value;
-        if (admOptionValue == nameSelect.value) {
-            document.getElementById("admDivCheck").style.display = "block";
-        }
-        else {
-            document.getElementById("admDivCheck").style.display = "none";
-        }
+let typeSelect = document.getElementById("type")
+typeSelect.addEventListener("change", function () {
+    let admOptionValue = document.getElementById("local").value;
+    if (admOptionValue == typeSelect.value) {
+        document.getElementById("admDivCheck").style.display = "block";
     }
     else {
         document.getElementById("admDivCheck").style.display = "none";
     }
-}
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -61,7 +61,7 @@
   "optional_permissions": [
   "bookmarks",
   "downloads",
-  "browserSettings",
+  "browserSettings"
   ],
   "manifest_version": 2
 }


### PR DESCRIPTION
Sorry, I think I missed the last message. 

This commit makes the last section only show when the third option is selected.

By the way I cannot see any text on the settings page, because the English translation file is incomplete. The default language is set to "en" in manifest.json:

    "default_locale": "en",

so only the English file will be used in other locales without translation file.